### PR TITLE
Add support for generated source files

### DIFF
--- a/elm/def.bzl
+++ b/elm/def.bzl
@@ -159,16 +159,25 @@ def _get_workspace_root(ctx):
         return "."
     return ctx.label.workspace_root
 
+def _paths_join(*args):
+    return "/".join([path for path in args if path])
+
 def _elm_library_impl(ctx):
-    source_directory = _get_workspace_root(ctx)
-    if ctx.attr.strip_import_prefix:
-        source_directory += "/" + ctx.attr.strip_import_prefix
+    workspace_root = _get_workspace_root(ctx)
+    source_directories_set = {}
+    for src in ctx.files.srcs:
+        source_directories_set.setdefault(_paths_join(
+            workspace_root,
+            src.root.path,  # non-empty for generated files.
+            ctx.attr.strip_import_prefix,
+        ))
+    source_directories = source_directories_set.keys()
     return [
         _create_elm_library_provider(
             ctx.attr.deps,
             [],
             [],
-            [source_directory],
+            source_directories,
             ctx.files.srcs,
         ),
     ]


### PR DESCRIPTION
Generated files are available under different paths than source files in the execroot. E.g.
```
./bazel-out/k8-fastbuild/bin/strip-prefix
```
instead of
```
./strip-prefix
```

However, we cannot just always add that path to the source directories. Otherwise, the Elm compiler will complain about a missing directory if there are no generated sources to a target.

This change avoids that issue by using the `File.root` attribute on each source file to determine if an additional path component is required.