### PR TITLE
Use elm 0.19.1

### DIFF
--- a/elm/compile.py
+++ b/elm/compile.py
@@ -4,7 +4,7 @@ import struct
 import subprocess
 import sys
 
-PACKAGES_DIR = "elm-home/0.19.0/package"
+PACKAGES_DIR = "elm-home/0.19.1/package"
 
 (
     arg_compilation_mode,
@@ -87,4 +87,4 @@ if arg_out_elmi != "":
     if elmi_file.endswith(".elm"):
         elmi_file = elmi_file[:-4]
     elmi_file += ".elmi"
-    os.rename(os.path.join("elm-stuff/0.19.0", elmi_file), arg_out_elmi)
+    os.rename(os.path.join("elm-stuff/0.19.1", elmi_file), arg_out_elmi)

--- a/elm/def.bzl
+++ b/elm/def.bzl
@@ -35,7 +35,7 @@ def _do_elm_make(
         """{
     "type": "application",
     "dependencies": {"direct": %s, "indirect": {}},
-    "elm-version": "0.19.0",
+    "elm-version": "0.19.1",
     "source-directories": %s,
     "test-dependencies": {"direct": {}, "indirect": {}}
 }""" %

--- a/elm/deps.bzl
+++ b/elm/deps.bzl
@@ -1,18 +1,14 @@
-load("@bazel_tools//tools/build_defs/repo:http.bzl", _http_archive = "http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", _http_archive = "http_archive", _http_file = "http_file")
 
 def elm_register_toolchains():
-    _http_archive(
+    _http_file(
         name = "com_github_elm_compiler_linux",
-        build_file_content = """exports_files(["elm"])""",
-        sha256 = "7a82bbf34955960d9806417f300e7b2f8d426933c09863797fe83b67063e0139",
-        urls = ["https://github.com/elm/compiler/releases/download/0.19.0/binaries-for-linux.tar.gz"],
+        urls = ["https://github.com/elm/compiler/releases/download/0.19.1/binary-for-linux-64-bit.gz"],
     )
 
-    _http_archive(
+    _http_file(
         name = "com_github_elm_compiler_mac",
-        build_file_content = """exports_files(["elm"])""",
-        sha256 = "18410e605208fc2b620f5e30bccbbd122c992a27de46f9f362271ce3dcc66962",
-        urls = ["https://github.com/elm/compiler/releases/download/0.19.0/binaries-for-mac.tar.gz"],
+        urls = ["https://github.com/elm/compiler/releases/download/0.19.1/binary-for-mac-64-bit.gz"],
     )
 
     _http_archive(
@@ -26,8 +22,8 @@ elm_library(
     visibility = ["//visibility:public"],
 )""",
         sha256 = "0a674bc62347b8476a4d54e432a65f49862278a9062fd86948dfafafb96c511d",
-        strip_prefix = "node-test-runner-0.19.0",
-        urls = ["https://github.com/rtfeldman/node-test-runner/archive/0.19.0.tar.gz"],
+        strip_prefix = "node-test-runner-0.19.1-revision2",
+        urls = ["https://github.com/rtfeldman/node-test-runner/archive/0.19.1-revision2.tar.gz"],
     )
 
     native.register_toolchains("@com_github_edschouten_rules_elm//elm/toolchain:linux")

--- a/elm/deps.bzl
+++ b/elm/deps.bzl
@@ -3,12 +3,12 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", _http_archive = "http_archi
 def elm_register_toolchains():
     _http_file(
         name = "com_github_elm_compiler_linux",
-        urls = ["https://github.com/elm/compiler/releases/download/0.19.1/binary-for-linux-64-bit.gz"],
+        urls = ["https://github.com/elm/compiler/releases/download/0.19.1/binary-for-linux-64-bit.gz"]
     )
 
     _http_file(
         name = "com_github_elm_compiler_mac",
-        urls = ["https://github.com/elm/compiler/releases/download/0.19.1/binary-for-mac-64-bit.gz"],
+        urls = ["https://github.com/elm/compiler/releases/download/0.19.1/binary-for-mac-64-bit.gz"]
     )
 
     _http_archive(


### PR DESCRIPTION
Needs review, simply changes the paths from 0.19.0 to 0.19.1.

The way we fetch the elm compiler archive probably needs to change because there's no `.tar.gz` files in the releases, @EdSchouten you can probably shed more light here as I'm not that experienced with Bazel.