### PR TITLE
Resolves #11

### DIFF
--- a/elm/compile.py
+++ b/elm/compile.py
@@ -30,6 +30,8 @@ for package_dir in sys.argv[7:]:
         os.path.join(internal_package_dir, metadata["version"]),
     )
 
+if len(sys.argv) <= 8:
+    os.makedirs(PACKAGES_DIR)
 
 def str_to_bytes(s):
     try:

--- a/elm/compile.py
+++ b/elm/compile.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 
 PACKAGES_DIR = "elm-home/0.19.0/package"
+os.makedirs(PACKAGES_DIR)
 
 (
     arg_compilation_mode,
@@ -29,9 +30,6 @@ for package_dir in sys.argv[7:]:
         os.path.abspath(package_dir),
         os.path.join(internal_package_dir, metadata["version"]),
     )
-
-if len(sys.argv) <= 8:
-    os.makedirs(PACKAGES_DIR)
 
 def str_to_bytes(s):
     try:


### PR DESCRIPTION
The cause of this issue was that `compile.py` never creates `PACKAGES_DIR` if a project has no dependencies. A project without any dependencies still will (and should) fail, since an elm binary needs to have `elm/core` as a dependency. However, the error message being generated in this case was confusing. It was previously:
```
Traceback (most recent call last):
  File "external/com_github_edschouten_rules_elm/elm/compile.py", line 44, in <module>
    with open(os.path.join(PACKAGES_DIR, "versions.dat"), "wb") as f:
FileNotFoundError: [Errno 2] No such file or directory: 'elm-home/0.19.0/package/versions.dat'
```
which provides very little information about the actual problem to the user. Generating the directory anyway (which is what this change does), makes it so a project without any dependencies still won't build (since it needs `elm/core`), but it will at least get as far as invoking the elm compiler, which will then end up throwing the (much more helpful) error message:
```
-- MISSING DEPENDENCY ------------------------------------------------- elm.json

An application must have "elm/core" as a dependency. Try running:

    elm install elm/core

It has some supporting code that is needed by every Elm application!
```
This is much more understandable to someone new to elm who might not necessarily already know that `elm/core` needs to be included.